### PR TITLE
Upgrade Java to 25, rename artifact to network-chat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+CLAUDE.md

--- a/pom.xml
+++ b/pom.xml
@@ -5,21 +5,20 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.example</groupId>
-    <artifactId>JavaMax</artifactId>
+    <artifactId>network-chat</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.release>25</maven.compiler.release>
+        <junit.version>5.12.2</junit.version>
     </properties>
 
-    <!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-api -->
     <dependencies>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.7.2</version>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -28,7 +27,18 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.15.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.5</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
+                <version>3.5.0</version>
                 <configuration>
                     <archive>
                         <manifest>


### PR DESCRIPTION
## Summary
- Rename artifactId from `JavaMax` to `network-chat`
- Upgrade Java from 11 to 25 (using `maven.compiler.release`)
- Upgrade junit-jupiter-api 5.7.2 → 5.12.2
- Pin plugin versions: maven-compiler-plugin 3.15.0, maven-surefire-plugin 3.5.5, maven-jar-plugin 3.5.0
- Add CLAUDE.md to .gitignore

## Test plan
- [x] `mvn clean test` passes
- [x] Server starts and listens on port 6666